### PR TITLE
Prevent TypeError: state.deltalog is not iterable

### DIFF
--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -470,7 +470,7 @@ export function Flow({
       logEntry.automatic = true;
     }
 
-    const deltalog = [...state.deltalog, logEntry];
+    const deltalog = [...(state.deltalog || []), logEntry];
 
     return { ...state, G, ctx, deltalog };
   }


### PR DESCRIPTION
#788 "UnhandledPromiseRejectionWarning: TypeError: state.deltalog is not iterable"

Everywhere else that deltalog is updated, it uses this (state.deltalog || []) pattern.

#### Checklist

* [ ] Use a separate branch in your local repo (not `master`).
* [ ] Test coverage is 100% (or you have a story for why it's ok).
